### PR TITLE
Fixed the order of the rules to

### DIFF
--- a/Jake.ts
+++ b/Jake.ts
@@ -3,8 +3,25 @@
 import * as ShellJs from "shelljs";
 export let Shell = ShellJs;//require("shelljs");
 
+let EnableLog: boolean = process.env.enableLog === "true";
+console.log("Logging is " + (EnableLog ? "enabled" : "disabled"));
+
 export function Log(msg) {
-  // console.log(msg);
+  if (EnableLog) {
+    console.log(msg);
+  }
+}
+
+interface Task extends jake.Task {
+  name?: string;
+  prereqs?: string[];
+  taskStatus?: string;
+}
+
+export function LogTask(t: Task) {
+  if (EnableLog) {
+    Log(`${t.taskStatus} => ${t.name}: ['${t.prereqs.join("', '")}']`);
+  }
 }
 
 export function Exec(cmd: string | string[], callback, isSilent?: boolean) {

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ JAKETS__DIR := $(subst //,,$(dir $(lastword $(MAKEFILE_LIST)))/)
 CURRENT__DIR := $(subst //,,$(dir $(firstword $(MAKEFILE_LIST)))/)
 
 EXPECTED_NODE_VERSION?=v5.10.1
+ENABLE_LOG?=false
 
 ###################################################################################################
 # setup platform dependent variables
@@ -52,6 +53,7 @@ ifneq "$(NODE_VERSION)" "$(EXPECTED_NODE_VERSION)"
 endif
 
 JAKE = $(NODE_MODULES__DIR)/.bin/jake
+JAKE__PARAMS = enableLog=$(ENABLE_LOG)
 
 #One can use the following local file to overwrite the above settings
 -include LocalPaths.mk
@@ -63,10 +65,10 @@ JAKE = $(NODE_MODULES__DIR)/.bin/jake
 # default: run_jake
 
 jts_run_jake: jts_compile_jake
-	$(JAKE)
+	$(JAKE) $(JAKE__PARAMS)
 
 j-%: jts_compile_jake
-	$(JAKE) $*
+	$(JAKE) $*  $(JAKE__PARAMS)
 
 #The following is auto generated to make sure local Jakefile.ts dependencies are captured properly
 -include Jakefile.mk
@@ -84,13 +86,13 @@ jts_compile_jake: jts_setup
 #
 
 jts_setup: $(JAKE) $(JAKETS__DIR)/Jakefile.js
-	$(JAKE) --jakefile $(JAKETS__DIR)/Jakefile.js jts:setup
-	$(JAKE) jts:generate_dependencies
+	$(JAKE) --jakefile $(JAKETS__DIR)/Jakefile.js jts:setup $(JAKE__PARAMS)
+	$(JAKE) jts:generate_dependencies $(JAKE__PARAMS)
 
 $(JAKETS__DIR)/Jakefile.js: $(JAKE) $(wildcard $(JAKETS__DIR)/*.ts $(JAKETS__DIR)/bootstrap/*.js)
 	cd $(JAKETS__DIR) && \
 	cp bootstrap/*.js .
-	$(JAKE) --jakefile $(JAKETS__DIR)/Jakefile.js jts:setup
+	$(JAKE) --jakefile $(JAKETS__DIR)/Jakefile.js jts:setup $(JAKE__PARAMS)
 	touch $@
 	echo ************** MAKE SURE YOU CALL make jts_update_bootstrap **************
 

--- a/NodeUtil.ts
+++ b/NodeUtil.ts
@@ -31,8 +31,8 @@ export function GetNodeCommand(
   testCmd: string, //command to test if there is one installed locally
   nodeCli: string //path to node file
 ) {
-  let localCli = path.join(LocalDir, "node_modules", nodeCli);
-  let jaketsCli = path.join(JaketsDir, "node_modules", nodeCli);
+  let localCli = path.resolve(path.join(LocalDir, "node_modules", nodeCli));
+  let jaketsCli = path.resolve(path.join(JaketsDir, "node_modules", nodeCli));
   let cmd = cmdName;
   try {
     if (fs.statSync(localCli)) {

--- a/bootstrap/Jake.js
+++ b/bootstrap/Jake.js
@@ -2,10 +2,20 @@
 "use strict";
 var ShellJs = require("shelljs");
 exports.Shell = ShellJs; //require("shelljs");
+var EnableLog = process.env.enableLog === "true";
+console.log("Logging is " + (EnableLog ? "enabled" : "disabled"));
 function Log(msg) {
-    // console.log(msg);
+    if (EnableLog) {
+        console.log(msg);
+    }
 }
 exports.Log = Log;
+function LogTask(t) {
+    if (EnableLog) {
+        Log(t.taskStatus + " => " + t.name + ": ['" + t.prereqs.join("', '") + "']");
+    }
+}
+exports.LogTask = LogTask;
 function Exec(cmd, callback, isSilent) {
     var cmdArray;
     if (Array.isArray(cmd)) {

--- a/bootstrap/NodeUtil.js
+++ b/bootstrap/NodeUtil.js
@@ -27,8 +27,8 @@ function GetNodeCommand(cmdName, //default command line
     testCmd, //command to test if there is one installed locally
     nodeCli //path to node file
     ) {
-    var localCli = path.join(LocalDir, "node_modules", nodeCli);
-    var jaketsCli = path.join(JaketsDir, "node_modules", nodeCli);
+    var localCli = path.resolve(path.join(LocalDir, "node_modules", nodeCli));
+    var jaketsCli = path.resolve(path.join(JaketsDir, "node_modules", nodeCli));
     var cmd = cmdName;
     try {
         if (fs.statSync(localCli)) {


### PR DESCRIPTION
1- install/update all packages
2- generate all typings
3- compile all Jakefile.ts files

Make the path of the commands absolute, so that they can be used from anywhere
Add a flag in makefile and jakefile to turn logging on/off. Other makefiles can overwrite this variable.
Make the nodejs version so that other makefiles can overwrite it (should be use with caution when jakets is shared among multiple projects)

with these changes, we can handle jakets included in the package.json of other projects.
